### PR TITLE
Switched the ordering of the Rebeliousness axis, which is currently broken

### DIFF
--- a/src/json/params.json
+++ b/src/json/params.json
@@ -202,13 +202,13 @@
                 "Revolutionaries think reform is an illusion, and strive for revolution anytime it's possible."
             ],
             "tiers": [
-                "Extreme Revolutionary",
-                "Revolutionary",
-                "Striker",
-                "Centrist",
-                "Pacifist",
+                "Constitutionalism",
                 "Reformism",
-                "Constitutionalism"
+                "Pacifist",
+                "Centrist",
+                "Striker",
+                "Revolutionary",
+                "Extreme Revolutionary"
             ]
         },
         {


### PR DESCRIPTION
The rebeliousness axis is borked. I noticed that having 100% reform, while other values at 50% gives you the value "extremely revolutionary" and the ideology social democracy, which doesn't make sense. This patch aims to solve this quick issue.